### PR TITLE
Add columns and ActiveModel::Validations support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 This project *tries* to adhere to [Semantic Versioning](http://semver.org/), even before v1.0.
 
+## [UNRELEASED]
+- Add a way to quickly define getters and setters using `column` method
+- Can be used with `ActiveModel::Validations`
+
 ## [1.1.1]
 - #6 from patchkit-net/feature/table-count: add Item.count
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ First define a class:
 ```ruby
 class Post < Dynomite::Item
   # partition_key "id" # optional, defaults to id
+  
+  column :id, :title, :desc
 end
 ```
 
@@ -92,6 +94,48 @@ Post.where({category: "Drama"}, {index_name: "category-index"})
 ```
 
 Examples are also in [item_spec.rb](spec/lib/dynomite/item_spec.rb).
+
+## Column Lists
+
+Optionally you can define your column list using `column` method inside your item class.
+Any columns defined that way can be easily accessed using getters and setters. Also, defined columns
+may be passed to validators.
+
+```ruby
+class Post < Dynomite::Item
+  column :id, :name
+end
+
+post = Post.new
+post.id = SecureRandom.uuid
+post.name = "My First Post"
+post.replace
+
+puts post.name # "My First Post"
+``` 
+
+Any column not defined using `column` method can still be accessed using `attrs` method.
+
+## Validations
+
+You can add validations known from ActiveRecord to your Dynomite items.
+Just add `include ActiveModel::Validations` at the top of your item class.
+
+```ruby
+class Post < Dynomite::Item
+  include ActiveModel::Validations
+  
+  column :id, :name # needed
+  
+  validate :id, presence: true
+  validate :name, presence: true
+end
+``` 
+
+**Be sure to define all validated columns using `column` method**.  
+
+Validations can be ran manually using `valid?` method. It is also executed internally by `replace`
+method, returning `false` on failed validation.
 
 ## Migration Support
 

--- a/lib/dynomite/reserved_words.rb
+++ b/lib/dynomite/reserved_words.rb
@@ -1,0 +1,18 @@
+module Dynomite
+  RESERVED_WORDS = %w[
+    as_json
+    attrs
+    attributes
+    delete
+    columns
+    find
+    getter
+    new_record
+    param_name
+    partition_key
+    replace
+    setter
+    scan
+    table_name
+  ].freeze
+end

--- a/spec/lib/dynomite/item_spec.rb
+++ b/spec/lib/dynomite/item_spec.rb
@@ -1,6 +1,7 @@
 require "spec_helper"
 
 class Post < Dynomite::Item
+  column :defined_column
 end
 class Comment < Dynomite::Item
   partition_key "post_id" # defaults to id
@@ -29,6 +30,36 @@ describe Dynomite::Item do
     it "partition_key" do
       expect(Post.partition_key).to eq "id"
       expect(Comment.partition_key).to eq "post_id"
+    end
+
+    it "uses defined column" do
+      post = Post.new
+      expect(post.defined_column).to be_nil
+      expect(post.attrs).to_not include('defined_column')
+
+      post.defined_column = 'abc'
+      expect(post.defined_column).to eq 'abc'
+      expect(post.attrs).to include('defined_column')
+    end
+
+    it "tries to use undefined column" do
+      post = Post.new
+      expect do
+        post.undefined_column
+      end.to raise_exception(NoMethodError)
+
+      post.attrs('undefined_column' => 'value')
+
+      # should not allow access while column is undefined
+      expect do
+        post.undefined_column
+      end.to raise_exception(NoMethodError)
+
+      Post.add_column('undefined_column')
+
+      expect do
+        post.undefined_column
+      end.to_not raise_exception(NoMethodError)
     end
   end
 


### PR DESCRIPTION
By including ActiveModel::Validations in the item,
ActiveRecord-like validations can be used when working with
Dynomite.

To get this working, I needed to implement a `column` method that
allows to define what columns *should* exist in every model.
Without it, ActiveModel::Validations couldn't tell if missing data
is a developer or user mistake.