### PR TITLE
Add custom errors fixing rspec warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 This project *tries* to adhere to [Semantic Versioning](http://semver.org/), even before v1.0.
 
+## [UNRELEASED]
+- Add custom Dynomite::Errors::ValidationError and Dynomite::Errors::ReservedWordError
+  fixing rspec warnings.
+
 ## [1.2.0]
 - #7 from patchkit-net/feature/validations
 - Add a way to quickly define getters and setters using `column` method

--- a/lib/dynomite.rb
+++ b/lib/dynomite.rb
@@ -18,6 +18,7 @@ module Dynomite
   autoload :Core, "dynomite/core"
   autoload :Erb, "dynomite/erb"
   autoload :Log, "dynomite/log"
+  autoload :Errors, "dynomite/errors"
 
   extend Core
 end

--- a/lib/dynomite/errors.rb
+++ b/lib/dynomite/errors.rb
@@ -1,0 +1,15 @@
+module Dynomite
+  module Errors
+    class ValidationError < StandardError
+      def initialize(msg)
+        super
+      end
+    end
+
+    class ReservedWordError < StandardError
+      def initialize(msg)
+        super
+      end
+    end
+  end
+end

--- a/lib/dynomite/item.rb
+++ b/lib/dynomite/item.rb
@@ -41,6 +41,7 @@ module Dynomite
   class Item
     include Log
     include DbConfig
+    include Errors
 
     def initialize(attrs={})
       @attrs = attrs
@@ -84,7 +85,7 @@ module Dynomite
     # Similar to replace, but raises an error on failed validation.
     # Works that way only if ActiveModel::Validations are included
     def replace!(hash={})
-      raise "Validation failed: #{errors.full_messages.join(', ')}" unless replace(hash)
+      raise ValidationError, "Validation failed: #{errors.full_messages.join(', ')}" unless replace(hash)
     end
 
     def find(id)
@@ -321,7 +322,9 @@ module Dynomite
 
     # @see Item.column
     def self.add_column(name)
-      raise "'#{name}' is a reserved word" if Dynomite::RESERVED_WORDS.include?(name)
+      if Dynomite::RESERVED_WORDS.include?(name)
+        raise ReservedWordError, "'#{name}' is a reserved word"
+      end
 
       define_method(name) do
         @attrs[name.to_s]

--- a/spec/lib/dynomite/item_spec.rb
+++ b/spec/lib/dynomite/item_spec.rb
@@ -60,7 +60,7 @@ describe Dynomite::Item do
 
       expect do
         post.undefined_column
-      end.to_not raise_exception(NoMethodError)
+      end.to_not raise_exception
     end
   end
 
@@ -185,13 +185,13 @@ describe Dynomite::Item do
 
     it "validates on replace!" do
       post = ValidatedItem.new
-      expect { post.replace! }.to raise_error(RuntimeError)
+      expect { post.replace! }.to raise_error(Dynomite::Errors::ValidationError)
       expect(post.errors.messages).to include(:first)
 
       expect(ValidatedItem.db).to receive(:put_item)
 
       post.first = 'content'
-      expect{ post.replace! }.to_not raise_error(RuntimeError)
+      expect{ post.replace! }.to_not raise_error
       expect(post.errors.messages.size).to eq 0
     end
   end


### PR DESCRIPTION
These errors were added to be raised instead of StandardError:
- Dynomite::Errors::ValidationError
- Dynomite::Errors::ReservedWordError