### PR TITLE
Fix README about validations

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,8 +128,8 @@ class Post < Dynomite::Item
   
   column :id, :name # needed
   
-  validate :id, presence: true
-  validate :name, presence: true
+  validates :id, presence: true
+  validates :name, presence: true
 end
 ``` 
 


### PR DESCRIPTION
Thanks for starting to support [Validations](https://github.com/tongueroo/dynomite#validations)!

When I tried to use it, I found that it is necessary to use `validates` not `validate` for using default Active Record validations.

According to [Rails Guides](https://guides.rubyonrails.org/active_record_validations.html#custom-methods), `validate` is used for validation of custom methods.

So I fix the example code of README.