### PR TITLE
update find method to support composite key

### DIFF
--- a/lib/dynomite/item.rb
+++ b/lib/dynomite/item.rb
@@ -236,9 +236,17 @@ module Dynomite
     end
 
     def self.find(id)
+      params =
+        case id
+        when String
+          { partition_key => id }
+        when Hash
+          id
+        end
+
       resp = db.get_item(
         table_name: table_name,
-        key: {partition_key => id}
+        key: params
       )
       attributes = resp.item # unwraps the item's attributes
       self.new(attributes) if attributes

--- a/spec/lib/dynomite/item_spec.rb
+++ b/spec/lib/dynomite/item_spec.rb
@@ -82,6 +82,14 @@ describe Dynomite::Item do
       expect(post.attrs).to eq("id" => "myid", "title" => "my title")
     end
 
+    it "find with hash" do
+      expect(Post.db).to receive(:get_item).and_return(find_resp)
+
+      post = Post.find(id: "myid")
+
+      expect(post.attrs).to eq("id" => "myid", "title" => "my title")
+    end
+
     it "replace" do
       # Not returning a resp with receive because it is not useful
       # Dynanmodb doesnt provide much useful info there.
@@ -196,4 +204,3 @@ describe Dynomite::Item do
     end
   end
 end
-


### PR DESCRIPTION
hi

I updated find method.
I think this is more convenient.
This change let you get item with not only partition key but also hash and range keys.

like below:

```
post = Post.find(id: "myid", title: "my title")
```

I hope this make sense.