### PR TITLE
Fixed typo in README examples create.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ end
 ```ruby
 post = Post.new
 post = post.replace(title: "test title")
-post.attrs # {"id" => "generated-id", title" => "my title"}
+post.attrs # {"id" => "generated-id", title" => "test title"}
 ```
 
 `post.attrs[:id]` now contain a generated unique partition_key id.  Usually the partition_key is 'id'. You can set your own unique id also by specifying id.


### PR DESCRIPTION
I found a typo in the README.
The key-value when replacing is different from the key-value in the comment indicating the result.