### PR TITLE
On Demand Pricing | DynamoDB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+vendor/bundle

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this project will be documented in this file.
 This project *tries* to adhere to [Semantic Versioning](http://semver.org/), even before v1.0.
 
+## [1.3.0]
+- Implement the `PAY_PER_USE` billing mode for table creations and updates. See [DynamoDB On Demand](https://aws.amazon.com/blogs/aws/amazon-dynamodb-on-demand-no-capacity-planning-and-pay-per-request-pricing/).
+
 ## [1.2.5]
 - use correct color method
 

--- a/docs/migrations/long-example.rb
+++ b/docs/migrations/long-example.rb
@@ -55,6 +55,9 @@ class CreateCommentsMigration < Dynomite::Migration
       #   read_capacity_units: 5,
       #   write_capacity_units: 5
       # )
+
+      # set the billing mode to on-demand (NOTE: this overrides provisioned_throughput)
+      # t.billing_mode(:pay_per_use)
     end
   end
 end
@@ -62,6 +65,8 @@ end
 class UpdateCommentsMigration < Dynomite::Migration
   def up
     update_table :comments do |t|
+      # You can update from provisioned_throughput to on-demand pricing
+      # t.billing_mode(:pay_per_use)
 
       # t.global_secondary_index do
       # t.gsi(METHOD, INDEX_NAME) do
@@ -120,4 +125,3 @@ class UpdateCommentsMigration < Dynomite::Migration
     end
   end
 end
-

--- a/lib/dynomite/migration/generator.rb
+++ b/lib/dynomite/migration/generator.rb
@@ -31,7 +31,7 @@ class Dynomite::Migration
         table_name: table_name,
         partition_key: @options[:partition_key],
         sort_key: @options[:sort_key],
-        provisioned_throughput: @options[:provisioned_throughput] || 5,
+        provisioned_throughput: @options[:provisioned_throughput] || 5
       )
     end
 

--- a/lib/dynomite/migration/templates/create_table.rb
+++ b/lib/dynomite/migration/templates/create_table.rb
@@ -5,6 +5,7 @@ class <%= @migration_class_name %> < Dynomite::Migration
 <% if @sort_key # so extra spaces are not added when generated -%>
       t.sort_key  "<%= @sort_key %>" # optional
 <% end -%>
+      t.billing_mode(:PROVISIONED)
       t.provisioned_throughput(<%= @provisioned_throughput %>) # sets both read and write, defaults to 5 when not set
 
       # Instead of using partition_key and sort_key you can set the

--- a/lib/dynomite/version.rb
+++ b/lib/dynomite/version.rb
@@ -1,3 +1,3 @@
 module Dynomite
-  VERSION = "1.2.5"
+  VERSION = "1.3.0"
 end

--- a/spec/lib/dynomite/migration/dsl_spec.rb
+++ b/spec/lib/dynomite/migration/dsl_spec.rb
@@ -1,6 +1,12 @@
 require "spec_helper"
 
 describe Dynomite::Migration::Dsl do
+  around(:each) do |example|
+    Dynomite::Migration::Dsl.db = Aws::DynamoDB::Client.new(stub_responses: true)
+    example.run
+    Dynomite::Migration::Dsl.db = nil
+  end
+
   # Supports this DSL, the `t` variable passed to the block is the Dsl instance
   #
   # class CreateCommentsMigration < Dynomite::Migration
@@ -8,61 +14,105 @@ describe Dynomite::Migration::Dsl do
   #     create_table :comments do |t|
   #       t.partition_key "post_id:string" # required
   #       t.sort_key  "created_at:string" # optional
+  #       t.billing_mode(:provisioned) # optional
   #       t.provisioned_throughput(5) # sets both read and write, defaults to 5 when not set
   #     end
   #   end
   # end
   context "create_table" do
-    let(:dsl) do
-      Dynomite::Migration::Dsl.db = double("db").as_null_object
-      Dynomite::Migration::Dsl.new(:create_table, "posts")
+    let(:dsl) { Dynomite::Migration::Dsl.new(:create_table, "posts") }
+    subject { dsl.params }
+
+    context "with billing_mode == :provisioned" do
+      before(:each) do
+        dsl.partition_key "id:string"
+        dsl.sort_key "created_at:string"
+        dsl.provisioned_throughput(25)
+      end
+
+      it "builds the DSL parameters in memory" do
+        expect(subject[:key_schema]).to eq([
+          {:attribute_name=>"id", :key_type=>"HASH"},
+          {:attribute_name=>"created_at", :key_type=>"RANGE"}])
+        expect(subject[:attribute_definitions]).to eq([
+          {:attribute_name=>"id", :attribute_type=>"S"},
+          {:attribute_name=>"created_at", :attribute_type=>"S"}])
+        expect(subject[:provisioned_throughput]).to eq(
+          :read_capacity_units=>25,
+          :write_capacity_units=>25
+        )
+        expect(subject[:billing_mode]).to eq("PROVISIONED")
+      end
     end
 
-    it "build up the dsl in memory" do
-      dsl.partition_key "id:string" # required
-      dsl.sort_key  "created_at:string" # optional
-      dsl.provisioned_throughput(25)
+    context "with billing_mode == :pay_per_use" do
+      before(:each) do
+        dsl.partition_key "PK:string"
+        dsl.sort_key "SK:string"
+        dsl.billing_mode(:pay_per_use)
+        # NOTE: billing_mode :pay_per_use will override provisioned_throughput
+        dsl.provisioned_throughput(25)
+      end
 
-      expect(dsl.key_schema).to eq([
-        {:attribute_name=>"id", :key_type=>"HASH"},
-        {:attribute_name=>"created_at", :key_type=>"RANGE"}])
-      expect(dsl.attribute_definitions).to eq([
-        {:attribute_name=>"id", :attribute_type=>"S"},
-        {:attribute_name=>"created_at", :attribute_type=>"S"}])
-      expect(dsl.provisioned_throughput).to eq(
-        :read_capacity_units=>25,
-        :write_capacity_units=>25
-      )
+      it "builds the DSL parameters in memory" do
+        expect(subject[:key_schema]).to eq([
+          { attribute_name: "PK", key_type: "HASH" },
+          { attribute_name: "SK", key_type: "RANGE" }
+        ])
+        expect(subject[:attribute_definitions]).to eq([
+          { attribute_name: "PK", attribute_type: "S"},
+          { attribute_name: "SK", attribute_type: "S"}
+        ])
+        expect(subject[:billing_mode]).to eq("PAY_PER_USE")
+        expect(subject[:provisioned_throughput]).to be_nil
+      end
     end
   end
 
   context "update_table" do
-    let(:dsl) do
-      Dynomite::Migration::Dsl.new(:update_table, "comments")
+    let(:dsl) { Dynomite::Migration::Dsl.new(:update_table, "comments") }
+
+    context "with billing_mode == :provisioned" do
+      it "builds up the gsi index params" do
+        dsl.provisioned_throughput(18)
+        allow(dsl).to receive(:gsi_attribute_definitions).and_return([])
+
+        dsl.gsi(:create) do |i|
+          i.partition_key "post_id:string"
+          i.sort_key "updated_at:string" # optional
+        end
+        dsl.gsi(:update, "another-index") do |i|
+          i.provisioned_throughput(8)
+        end
+        dsl.gsi(:delete, "old-index")
+
+        params = dsl.params
+        # pp params # uncomment out to inspect params
+        # attribute_definitions is a Double because we've mocked out:
+        # Dynomite::Migration::Dsl.db = double("db").as_null_object
+        expect(params.key?(:attribute_definitions)).to be true
+        expect(params.key?(:global_secondary_index_updates)).to be true
+        global_secondary_index_updates = params[:global_secondary_index_updates]
+        index_actions = global_secondary_index_updates.map {|hash| hash.keys.first }
+        expect(index_actions.sort).to eq([:create, :update, :delete].sort)
+        expect(params[:provisioned_throughput]).to eq(
+          read_capacity_units: 18,
+          write_capacity_units: 18
+        )
+      end
     end
 
-    it "builds up the gsi index params" do
-      dsl.provisioned_throughput(18)
-      allow(dsl).to receive(:gsi_attribute_definitions).and_return([])
+    context "with billing_mode == :pay_per_use" do
+      subject { dsl.params }
 
-      dsl.gsi(:create) do |i|
-        i.partition_key "post_id:string"
-        i.sort_key "updated_at:string" # optional
+      before(:each) do
+        dsl.billing_mode(:pay_per_use)
       end
-      dsl.gsi(:update, "another-index") do |i|
-        i.provisioned_throughput(8)
-      end
-      dsl.gsi(:delete, "old-index")
 
-      params = dsl.params
-      # pp params # uncomment out to inspect params
-      # attribute_definitions is a Double because we've mocked out:
-      # Dynomite::Migration::Dsl.db = double("db").as_null_object
-      expect(params.key?(:attribute_definitions)).to be true
-      expect(params.key?(:global_secondary_index_updates)).to be true
-      global_secondary_index_updates = params[:global_secondary_index_updates]
-      index_actions = global_secondary_index_updates.map {|hash| hash.keys.first }
-      expect(index_actions.sort).to eq([:create, :update, :delete].sort)
+      it "sets the billing mode" do
+        expect(subject[:billing_mode]).to eq('PAY_PER_USE')
+        expect(subject[:provisioned_throughput]).to be_nil
+      end
     end
   end
 
@@ -73,4 +123,3 @@ describe Dynomite::Migration::Dsl do
   #   # dsl.execute # TODO: dsl.execute in here
   # end
 end
-


### PR DESCRIPTION
Hi there! Thanks for making great tools such as Jets and Dynomite!

I noticed that Dynomite didn't support DynamoDB's [On-Demand](https://aws.amazon.com/blogs/aws/amazon-dynamodb-on-demand-no-capacity-planning-and-pay-per-request-pricing/) pricing, so I added it!

I took the liberty to bump the version and `CHANGELOG`. If you would prefer to do this yourself, please let me know and I'll amend the commit.

Also I tend to vendorize my gems from bundler locally, so I added `vendor/bundle` to the gitignore.

Finally, I noticed this repo has tests, but no CI setup. It should be pretty simple to setup [GitHub Actions](https://github.com/features/actions) for free. Would you like me to take care of that?

Thanks!

### Notes

* Add a `billing_mode` option to migrations so that it's possible
  to utilize On-Demand pricing [1].
* The new option can be utilized in create or update migrations
  as follows:

```ruby
t.billing_mode(:pay_per_use)
```

* Note that the `:pay_per_use` billing option will override
  any previous configured `:provisioned_throughput` and the
  table will convert to on-demand capacity and pricing.
* Use the aws-sdk-ruby built in stubs for tests so that
  doubled client instances don't leak into other test cases [2].

[1]: https://aws.amazon.com/blogs/aws/amazon-dynamodb-on-demand-no-capacity-planning-and-pay-per-request-pricing/
[2]: https://aws.amazon.com/blogs/developer/advanced-client-stubbing-in-the-aws-sdk-for-ruby-version-3/