### PR TITLE
change pay_per_use to pay_per_request

### DIFF
--- a/docs/migrations/long-example.rb
+++ b/docs/migrations/long-example.rb
@@ -57,7 +57,7 @@ class CreateCommentsMigration < Dynomite::Migration
       # )
 
       # set the billing mode to on-demand (NOTE: this overrides provisioned_throughput)
-      # t.billing_mode(:pay_per_use)
+      # t.billing_mode(:pay_per_request)
     end
   end
 end
@@ -66,7 +66,7 @@ class UpdateCommentsMigration < Dynomite::Migration
   def up
     update_table :comments do |t|
       # You can update from provisioned_throughput to on-demand pricing
-      # t.billing_mode(:pay_per_use)
+      # t.billing_mode(:pay_per_request)
 
       # t.global_secondary_index do
       # t.gsi(METHOD, INDEX_NAME) do

--- a/spec/lib/dynomite/migration/dsl_spec.rb
+++ b/spec/lib/dynomite/migration/dsl_spec.rb
@@ -45,12 +45,12 @@ describe Dynomite::Migration::Dsl do
       end
     end
 
-    context "with billing_mode == :pay_per_use" do
+    context "with billing_mode == :pay_per_request" do
       before(:each) do
         dsl.partition_key "PK:string"
         dsl.sort_key "SK:string"
-        dsl.billing_mode(:pay_per_use)
-        # NOTE: billing_mode :pay_per_use will override provisioned_throughput
+        dsl.billing_mode(:pay_per_request)
+        # NOTE: billing_mode :pay_per_request will override provisioned_throughput
         dsl.provisioned_throughput(25)
       end
 
@@ -63,7 +63,7 @@ describe Dynomite::Migration::Dsl do
           { attribute_name: "PK", attribute_type: "S"},
           { attribute_name: "SK", attribute_type: "S"}
         ])
-        expect(subject[:billing_mode]).to eq("PAY_PER_USE")
+        expect(subject[:billing_mode]).to eq("PAY_PER_REQUEST")
         expect(subject[:provisioned_throughput]).to be_nil
       end
     end
@@ -102,15 +102,15 @@ describe Dynomite::Migration::Dsl do
       end
     end
 
-    context "with billing_mode == :pay_per_use" do
+    context "with billing_mode == :pay_per_request" do
       subject { dsl.params }
 
       before(:each) do
-        dsl.billing_mode(:pay_per_use)
+        dsl.billing_mode(:pay_per_request)
       end
 
       it "sets the billing mode" do
-        expect(subject[:billing_mode]).to eq('PAY_PER_USE')
+        expect(subject[:billing_mode]).to eq('PAY_PER_REQUEST')
         expect(subject[:provisioned_throughput]).to be_nil
       end
     end


### PR DESCRIPTION
Thanks for making ruby on jets and dynomite.
I use these gems a lot.

I migrated a table in dynamodb with below code.
```
t.billing_mode(:pay_per_use)
```

But, error that `PAY_PER_REQUEST` or `PROVISIONED` must be selected is returned.
I changed pay_per_use to pay_per_request, then it worked.

Reference: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html