### PR TITLE
Adds support for setting sort_key on an Item class

### DIFF
--- a/lib/dynomite/item.rb
+++ b/lib/dynomite/item.rb
@@ -51,6 +51,10 @@ module Dynomite
       self.class.partition_key
     end
 
+    def sort_key
+      self.class.sort_key
+    end
+
     # For render json: item
     def as_json(options={})
       @attrs

--- a/lib/dynomite/item/dsl.rb
+++ b/lib/dynomite/item/dsl.rb
@@ -16,6 +16,15 @@ class Dynomite::Item
       end
     end
 
+    def sort_key(*args)
+      case args.size
+      when 0
+        @sort_key
+      when 1
+        @sort_key = args[0].to_sym
+      end
+    end
+
     # Defines column. Defined column can be accessed by getter and setter methods of the same
     # name (e.g. [model.my_column]). Attributes with undefined columns can be accessed by
     # [model.attrs] method.

--- a/spec/dynomite/item_spec.rb
+++ b/spec/dynomite/item_spec.rb
@@ -3,6 +3,7 @@ class Post < Dynomite::Item
 end
 class Comment < Dynomite::Item
   partition_key :post_id # defaults to :id
+  sort_key :timestamp
 end
 module Ns
   class Pet < Dynomite::Item; end
@@ -27,6 +28,11 @@ describe Dynomite::Item do
     it "partition_key" do
       expect(Post.partition_key).to eq :id
       expect(Comment.partition_key).to eq :post_id
+    end
+
+    it "sort_key" do
+      expect(Post.sort_key).to be_nil
+      expect(Comment.sort_key).to eq :timestamp
     end
 
     it "uses defined column" do


### PR DESCRIPTION
DynamoDB allows a table's primary key to be composed of a sort key in addition to a partition_key.
This enhancement allows for setting an optional `sort_key` attribute on the `Item` class.