### PR TITLE
Query by partition key

### DIFF
--- a/lib/dynomite/item/indexes/finder.rb
+++ b/lib/dynomite/item/indexes/finder.rb
@@ -4,9 +4,19 @@ module Dynomite::Item::Indexes
       @source, @query = source, query
     end
 
+    def find
+      find_primary_index || find_secondary_index
+    end
+
+    def find_primary_index
+      if fields.include?(@source.partition_key.to_s)
+        PrimaryIndex.new(@source.partition_key.to_s)
+      end
+    end
+
     # It's possible to have multiple indexes with the same partition and sort key.
     # Will use the first one we find.
-    def find
+    def find_secondary_index
       @source.indexes.find do |i|
         intersect = fields & i.fields
         intersect == i.fields

--- a/lib/dynomite/item/indexes/primary_index.rb
+++ b/lib/dynomite/item/indexes/primary_index.rb
@@ -1,0 +1,17 @@
+module Dynomite::Item::Indexes
+  class PrimaryIndex
+    def initialize(field)
+      @field = field
+    end
+
+    attr_reader :field
+
+    def index_name
+      nil
+    end
+
+    def fields
+      Array(field)
+    end
+  end
+end

--- a/lib/dynomite/item/query/builder.rb
+++ b/lib/dynomite/item/query/builder.rb
@@ -78,7 +78,7 @@ module Dynomite::Item::Query
         puts "params:"
         pp params
       end
-      if params[:index_name]
+      if params[:key_condition_expression]
         perform(:query, params)
       else
         Dynomite.logger.info("WARN: Scan operations are slow. Considering using an index.")

--- a/spec/dynomite/item_spec.rb
+++ b/spec/dynomite/item_spec.rb
@@ -194,7 +194,7 @@ describe Dynomite::Item do
 
     it "validates on save!" do
       post = ValidatedItem.new
-      expect { post.save! }.to raise_error(Dynomite::Errors::ValidationError)
+      expect { post.save! }.to raise_error(Dynomite::Error::Validation)
       expect(post.errors.messages).to include(:first)
 
       expect(ValidatedItem.db).to receive(:put_item)


### PR DESCRIPTION
In a DynamoDB table that has a partition key and sort key, you may want to query the table by the partition key only using the primary index. This change enables that, and automatically detects and uses the index. Usage example:
```
class Comment < Dynomite::Item
  partition_key :post_id
  sort_key :timestamp 
end

Comment.where(post_id: 'abcdef') # uses key-condition-expression: "#post_id = :post_id" on the primary index
```