### PR TITLE
Fix Item#reload for tables with a sort key

### DIFF
--- a/lib/dynomite/item.rb
+++ b/lib/dynomite/item.rb
@@ -68,7 +68,11 @@ module Dynomite
     def reload
       if persisted?
         id = @attrs[partition_key]
-        item = find(id) # item has different object_id
+        item = if sort_key
+                 find(partition_key => id, sort_key => @attrs[sort_key])
+               else
+                 find(id) # item has different object_id
+               end
         @attrs = item.attrs # replace current loaded attributes
       end
       self

--- a/spec/dynomite/item_spec.rb
+++ b/spec/dynomite/item_spec.rb
@@ -148,6 +148,33 @@ describe Dynomite::Item do
 
       expect(Post.count).to eq 1
     end
+
+    it "reload" do
+      fake_attributes = {"id" => "myid", "title" => "my title"}
+      post_resp = double(:resp)
+      expect(post_resp).to receive(:item).and_return(fake_attributes).twice
+      expect(Post.db).to receive(:get_item).and_return(post_resp).twice
+
+      post = Post.find(id: "myid")
+      post.reload
+
+      expect(post.attrs).to eq("id" => "myid", "title" => "my title")
+    end
+
+    it "reload with sort key" do
+      fake_attributes = {"post_id" => "myid", "title" => "my title", "timestamp" => 12345}
+      comment_resp = double(:resp)
+      expect(comment_resp).to receive(:item).and_return(fake_attributes).twice
+
+      expect(Comment.db).to receive(:get_item).
+        with(table_name: 'dynomite_comments', key: { post_id: "myid", timestamp: 12345 }).
+        and_return(comment_resp).twice
+
+      comment = Comment.find(post_id: "myid", timestamp: 12345)
+      comment.reload
+
+      expect(comment.attrs).to eq("post_id" => "myid", "title" => "my title", "timestamp" => 12345)
+    end
   end
 
   describe "validations" do


### PR DESCRIPTION
DynamoDB tables that are created with both a partition key and sort key require both keys when retrieving a single record using `Dynomite::Item#find`. This updates the `Dynomite::Item#reload` method to properly query using both keys when reloading the object from DynamoDB.