### PR TITLE
Implements Dynomite::Item#destroy on a table with a sort key

### DIFF
--- a/lib/dynomite/item/query/write/destroy.rb
+++ b/lib/dynomite/item/query/write/destroy.rb
@@ -1,7 +1,7 @@
 module Dynomite::Item::Query::Write
   class Destroy < Base
     def call
-      key = @model.attrs.slice(@model.class.partition_key)
+      key = @model.attrs.slice(@model.class.partition_key, @model.class.sort_key)
       params = {
         table_name: @model.class.table_name,
         key: key


### PR DESCRIPTION
When calling `Dynomite::Item#destroy` on an item in a table with a defined sort key, include the sort key in the query.