### PR TITLE
Add Item#delete_attribute to remove an attribute from a record

### DIFF
--- a/lib/dynomite/item.rb
+++ b/lib/dynomite/item.rb
@@ -42,6 +42,10 @@ module Dynomite
       @attrs[field.to_sym]
     end
 
+    def delete_attribute(field)
+      @attrs.delete(field.to_sym)
+    end
+
     def update_attribute(field, value)
       write_attribute(field, value)
       update(@attrs, {validate: false})

--- a/spec/dynomite/item_spec.rb
+++ b/spec/dynomite/item_spec.rb
@@ -127,6 +127,16 @@ describe Dynomite::Item do
       expect(Post.db).to have_received(:delete_item)
     end
 
+    it "delete_attribute" do
+      expect(Post.db).to receive(:put_item)
+
+      post = Post.new(title: "my title", extras: "anything you want")
+      post.save
+      expect(post.attrs[:extras]).to eq "anything you want"
+      post.delete_attribute(:extras)
+      expect(post.attrs.keys).to_not include('extras')
+    end
+
     let(:scan_resp) do
       fake_attributes = [{"id" => "myid", "title" => "my title"}]
       resp = double(:resp)


### PR DESCRIPTION
Adds a method to remove an attribute from an existing record.